### PR TITLE
fix: write export files for custom loaders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+*.js
+*.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,16 @@ dist/
 **/*.d.ts
 !src/**/*.d.ts
 **/*.tsbuildinfo
-!jest.config.js
+
 !browser.d.ts
+!browser.js
+!browser.mjs
 !cairo.d.ts
+!cairo.js
+!cairo.mjs
 !skia.d.ts
+!skia.js
+!skia.mjs
 
 # Ignore heapsnapshot and log files
 *.heapsnapshot

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/browser.js'), exports);

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,0 +1,1 @@
+export * from './dist/browser.mjs';

--- a/cairo.js
+++ b/cairo.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/cairo.js'), exports);

--- a/cairo.mjs
+++ b/cairo.mjs
@@ -1,0 +1,1 @@
+export * from './dist/cairo.mjs';

--- a/package.json
+++ b/package.json
@@ -76,8 +76,14 @@
 	"files": [
 		"dist",
 		"browser.d.ts",
+		"browser.js",
+		"browser.mjs",
 		"cairo.d.ts",
-		"skia.d.ts"
+		"cairo.js",
+		"cairo.mjs",
+		"skia.d.ts",
+		"skia.js",
+		"skia.mjs"
 	],
 	"engines": {
 		"node": ">=14"
@@ -131,5 +137,8 @@
 	"eslintConfig": {
 		"extends": "@sapphire"
 	},
-	"prettier": "@sapphire/prettier-config"
+	"prettier": "@sapphire/prettier-config",
+	"dependencies": {
+		"tslib": "^2.3.0"
+	}
 }

--- a/skia.js
+++ b/skia.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/skia.js'), exports);

--- a/skia.mjs
+++ b/skia.mjs
@@ -1,0 +1,1 @@
+export * from './dist/skia.mjs';


### PR DESCRIPTION
Without this, packages that use custom loaders such as Jest, cause errors.
