### PR TITLE
fix: restore state in `printResponsiveText`

### DIFF
--- a/src/lib/BaseCanvas.ts
+++ b/src/lib/BaseCanvas.ts
@@ -375,7 +375,7 @@ export abstract class BaseCanvas<
 
 		const { width } = this.measureText(text);
 		const newHeight = maxWidth > width ? height : (maxWidth / width) * height;
-		return this.setTextFont(`${tail}${newHeight}${lead}`).printText(text, x, y);
+		return this.save().setTextFont(`${tail}${newHeight}${lead}`).printText(text, x, y).restore();
 	}
 
 	/**


### PR DESCRIPTION
The method changes the font's size, so it needs to save and restore the state, that way it does not affect sub-sequent calls.

Fixes #383
