### PR TITLE
fix(browser): access from `globalThis`

### DIFF
--- a/src/main.ts.template
+++ b/src/main.ts.template
@@ -2378,7 +2378,7 @@ interface ResolvedCircularCoordinates {
 // IF(SKIA): export { Path2D, FontLibrary, NativeImage as Image, loadImage };
 
 // IF(BROWSER):                                                                                                        \
-export const Image = HTMLImageElement;                                                                                 \
+export const Image = globalThis.HTMLImageElement;                                                                      \
 export function loadImage(src: string, options?: Partial<HTMLImageElement>): Promise<HTMLImageElement> {               \
 	return new Promise<HTMLImageElement>((resolve, reject) => {                                                        \
 		// eslint-disable-next-line no-undef                                                                           \


### PR DESCRIPTION
This fixes a `ReferenceError` from SSR environments such as Nuxt's
